### PR TITLE
Fix missing context bug in VaultLoader listener

### DIFF
--- a/lib/config/app.dart
+++ b/lib/config/app.dart
@@ -1,5 +1,7 @@
 import 'package:fluro/fluro.dart';
+import 'package:flutter/material.dart';
 
 class AppConfig {
   static late FluroRouter router;
+  static late GlobalKey<NavigatorState> navigatorKey;
 }

--- a/lib/widgets/account_expired.dart
+++ b/lib/widgets/account_expired.dart
@@ -56,6 +56,10 @@ class _AccountExpiredWidgetState extends State<AccountExpiredWidget> {
                             await BlocProvider.of<VaultCubit>(context).signout();
                             final accountCubit = BlocProvider.of<AccountCubit>(context);
                             await accountCubit.signout();
+                            // Potential loss of context here but I think because the account cubit emit is the
+                            // last thing to happen in the signout task Flutter won't have had a chance to draw
+                            // a new frame and detach this defunct widget from the context. If WTFs happen around
+                            // here though, this is a strong candidate for the cause of the problem.
                             AppConfig.router.navigateTo(context, Routes.root, clearStack: true);
                           },
                           child: Text(str.signin),
@@ -71,6 +75,7 @@ class _AccountExpiredWidgetState extends State<AccountExpiredWidget> {
                         ),
                         ElevatedButton(
                           onPressed: () async {
+                            // Potential loss of context here as per above comment
                             await BlocProvider.of<VaultCubit>(context).signout();
                             final accountCubit = BlocProvider.of<AccountCubit>(context);
                             await accountCubit.signout();
@@ -109,6 +114,7 @@ class _AccountExpiredWidgetState extends State<AccountExpiredWidget> {
                       label: Icon(Icons.open_in_new),
                       onPressed: () async {
                         await DialogUtils.openUrl(EnvironmentConfig.webUrl + '/#pfEmail=$userEmail,dest=manageAccount');
+                        // Potential loss of context here as per earlier comment
                         await BlocProvider.of<VaultCubit>(context).signout();
                         final accountCubit = BlocProvider.of<AccountCubit>(context);
                         await accountCubit.signout();

--- a/lib/widgets/autofill_save.dart
+++ b/lib/widgets/autofill_save.dart
@@ -64,8 +64,11 @@ class _AutofillSaveWidgetState extends State<AutofillSaveWidget> {
 
   onEndEditing(bool keepChanges, VaultCubit vaultCubit, List<String> tags) async {
     final entryCubit = BlocProvider.of<EntryCubit>(context);
+    final autofillCubit = BlocProvider.of<AutofillCubit>(context);
     if (keepChanges && (entryCubit.state as EntryLoaded).entry.isDirty) {
       entryCubit.endEditing(newEntry);
+
+      final filterCubit = BlocProvider.of<FilterCubit>(context);
 
       // We skip remote upload for now because it could take a long time
       // and interrupt the user's priority task for too long.
@@ -77,7 +80,6 @@ class _AutofillSaveWidgetState extends State<AutofillSaveWidget> {
       // User may return to this Kee Vault instance in future and will
       // want the filter options to reflect any changes made while
       // adding this new entry
-      final filterCubit = BlocProvider.of<FilterCubit>(context);
       filterCubit.reFilter(tags, vaultCubit.currentVaultFile!.files.current.body.rootGroup);
     } else {
       entryCubit.endEditing(null);
@@ -92,7 +94,6 @@ class _AutofillSaveWidgetState extends State<AutofillSaveWidget> {
       );
     }
 
-    final autofillCubit = BlocProvider.of<AutofillCubit>(context);
     autofillCubit.finishSaving();
   }
 

--- a/lib/widgets/bottom.dart
+++ b/lib/widgets/bottom.dart
@@ -43,6 +43,9 @@ class BottomDrawerWidget extends StatelessWidget {
                   if (state is VaultLoaded && !autofillSimpleUIMode(autoFillState)) Divider(),
                   AccountDrawerWidget(emailAddress: emailAddress, user: user, str: str),
                   Divider(),
+                  // Maybe small chance of context being lost in between navigator pop and next navigation request?
+                  // Hasn't happened yet and may not be possible but if mysterious WTF errors are thrown on navigation
+                  // on some devices, could look there as a starting point.
                   if (state is VaultLoaded && !autofillSimpleUIMode(autoFillState))
                     ListTile(
                       leading: Icon(Icons.flash_on),
@@ -320,11 +323,12 @@ class _SaveButtonWidgetState extends State<SaveButtonWidget> {
       child: OutlinedButton(
           onPressed: () async {
             if (!widget.visible) return;
-            await BlocProvider.of<InteractionCubit>(context).databaseSaved();
-            await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.vaultSaved);
-            final cubit = BlocProvider.of<VaultCubit>(context);
+            final iam = InAppMessengerWidget.of(context);
+            final vaultCubit = BlocProvider.of<VaultCubit>(context);
             final accCubit = BlocProvider.of<AccountCubit>(context);
-            cubit.save(accCubit.currentUserIfKnown);
+            await BlocProvider.of<InteractionCubit>(context).databaseSaved();
+            await iam.showIfAppropriate(InAppMessageTrigger.vaultSaved);
+            vaultCubit.save(accCubit.currentUserIfKnown);
           },
           child: Text(widget.title)),
     );

--- a/lib/widgets/entry_list.dart
+++ b/lib/widgets/entry_list.dart
@@ -271,17 +271,18 @@ class EntryListItemWidget extends StatelessWidget {
                     },
                     onClosed: (bool? keepChanges) async {
                       final entryCubit = BlocProvider.of<EntryCubit>(context);
+                      final iam = InAppMessengerWidget.of(context);
                       if ((keepChanges == null || keepChanges) && (entryCubit.state as EntryLoaded).entry.isDirty) {
                         entryCubit.endEditing(entry);
-                        await BlocProvider.of<InteractionCubit>(context).entrySaved();
-                        await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.entryChanged);
                         final filterCubit = BlocProvider.of<FilterCubit>(context);
+                        await BlocProvider.of<InteractionCubit>(context).entrySaved();
+                        await iam.showIfAppropriate(InAppMessageTrigger.entryChanged);
                         filterCubit.reFilter(entry.file!.tags, entry.file!.body.rootGroup);
                         //TODO:f: A separate cubit to track state of ELIVMs might provide better performance and scroll position stability than recreating them all from scratch every time we re-filter?
                       } else {
                         entryCubit.endEditing(null);
                         vaultCubit.applyPendingChangesIfSafe(BlocProvider.of<AccountCubit>(context).currentUserIfKnown);
-                        await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.entryUnchanged);
+                        await iam.showIfAppropriate(InAppMessageTrigger.entryUnchanged);
                       }
                     },
                     closedBuilder: (context, open) {

--- a/lib/widgets/group_move_tree.dart
+++ b/lib/widgets/group_move_tree.dart
@@ -223,8 +223,9 @@ class _EntryMoveTreeListWidgetState extends _MoveTreeListWidgetState {
             supportParentDoubleTap: false,
             onNodeTap: (key) {
               Node<String>? selectedNode = _treeViewController.getNode(key);
+              final nav = Navigator.of(context);
               BlocProvider.of<EntryCubit>(context).updateGroupByUUID(uuid: selectedNode!.data!);
-              Navigator.of(context).pop(true);
+              nav.pop(true);
             },
             onExpansionChanged: (String key, bool expanded) {
               Node<String>? node = _treeViewController.getNode(key);

--- a/lib/widgets/kee_vault_app.dart
+++ b/lib/widgets/kee_vault_app.dart
@@ -37,15 +37,19 @@ class KeeVaultApp extends TraceableStatefulWidget {
   const KeeVaultApp({Key? key, required this.navigatorKey}) : super(key: key);
   @override
   State createState() {
-    return KeeVaultAppState();
+    //TODO:f: Perhaps there is some other place we can assign the AppConfig state
+    // rather than in this widget state constructor? Appears to work just fine though.
+    // ignore: no_logic_in_create_state
+    return KeeVaultAppState(navigatorKey);
   }
 }
 
 class KeeVaultAppState extends State<KeeVaultApp> with WidgetsBindingObserver {
-  KeeVaultAppState() {
+  KeeVaultAppState(GlobalKey<NavigatorState> navigatorKey) {
     final router = FluroRouter();
     Routes.configureRoutes(router);
     AppConfig.router = router;
+    AppConfig.navigatorKey = navigatorKey;
     userService = UserService(EnvironmentConfig.stage.toStage(), null);
     storageService = StorageService(EnvironmentConfig.stage.toStage(), userService.refresh);
   }

--- a/lib/widgets/new_entry_button.dart
+++ b/lib/widgets/new_entry_button.dart
@@ -52,17 +52,18 @@ class NewEntryButton extends StatelessWidget {
             },
             onClosed: (bool? keepChanges) async {
               final entryCubit = BlocProvider.of<EntryCubit>(context);
+              final iam = InAppMessengerWidget.of(context);
               if ((keepChanges == null || keepChanges) && (entryCubit.state as EntryLoaded).entry.isDirty) {
                 entryCubit.endCreating(currentFile);
-                await BlocProvider.of<InteractionCubit>(context).entrySaved();
-                await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.entryChanged);
                 final filterCubit = BlocProvider.of<FilterCubit>(context);
+                await BlocProvider.of<InteractionCubit>(context).entrySaved();
+                await iam.showIfAppropriate(InAppMessageTrigger.entryChanged);
                 filterCubit.reFilter(currentFile.tags, currentFile.body.rootGroup);
               } else {
                 entryCubit.endCreating(null);
                 final vaultCubit = BlocProvider.of<VaultCubit>(context);
                 vaultCubit.applyPendingChangesIfSafe(BlocProvider.of<AccountCubit>(context).currentUserIfKnown);
-                await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.entryUnchanged);
+                await iam.showIfAppropriate(InAppMessageTrigger.entryUnchanged);
               }
             },
             closedBuilder: (context, open) {

--- a/lib/widgets/password_preset_manager.dart
+++ b/lib/widgets/password_preset_manager.dart
@@ -202,6 +202,10 @@ class _PasswordPresetManagerWidgetState extends State<PasswordPresetManagerWidge
                         OutlinedButton(
                             child: Text(str.alertCancel.toUpperCase()),
                             onPressed: () {
+                              // Potential loss of context here but I think because the generator profiles cubit emit
+                              // is the last thing to happen in the discardNewProfile task Flutter won't have had a
+                              // chance to draw a new frame and detach this defunct widget from the context. If WTFs
+                              // happen around here though, this is a strong candidate for the cause of the problem.
                               final cubit = BlocProvider.of<GeneratorProfilesCubit>(context);
                               cubit.discardNewProfile();
                               Navigator.of(context).pop(true);
@@ -209,6 +213,7 @@ class _PasswordPresetManagerWidgetState extends State<PasswordPresetManagerWidge
                         OutlinedButton(
                             child: Text(str.add.toUpperCase()),
                             onPressed: () async {
+                              // Potential loss of context here as per above comment
                               final cubit = BlocProvider.of<GeneratorProfilesCubit>(context);
                               cubit.addNewProfile();
                               Navigator.of(context).pop(true);

--- a/lib/widgets/reset_account_prompt_dialog.dart
+++ b/lib/widgets/reset_account_prompt_dialog.dart
@@ -63,10 +63,12 @@ class _ResetAccountPromptDialogState extends State<ResetAccountPromptDialog> {
       final result = await mailerService.signup(_controller.text.toLowerCase());
       if (result) {
         l.d('signup successful');
+        final sm = ScaffoldMessenger.of(context);
+        final appSettingsCubit = BlocProvider.of<AppSettingsCubit>(context);
         Navigator.of(context).pop(true);
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(str.prcRegistrationSuccess)));
+        sm.showSnackBar(SnackBar(content: Text(str.prcRegistrationSuccess)));
         MatomoTracker.trackEvent('prcSignup', 'home');
-        await BlocProvider.of<AppSettingsCubit>(context).iamEmailSignupSuppressUntil(DateTime(2122));
+        await appSettingsCubit.iamEmailSignupSuppressUntil(DateTime(2122));
       } else {
         l.e('signup failed');
         setState(() {

--- a/lib/widgets/vault_drawer.dart
+++ b/lib/widgets/vault_drawer.dart
@@ -40,10 +40,13 @@ class VaultDrawerWidget extends StatelessWidget {
             ElevatedButton(
               onPressed: isSaveEnabled
                   ? () async {
+                      final iam = InAppMessengerWidget.of(context);
+                      final accountCubit = BlocProvider.of<AccountCubit>(context);
+                      final vaultCubit = BlocProvider.of<VaultCubit>(context);
                       await BlocProvider.of<InteractionCubit>(context).databaseSaved();
-                      await InAppMessengerWidget.of(context).showIfAppropriate(InAppMessageTrigger.vaultSaved);
-                      User? user = BlocProvider.of<AccountCubit>(context).currentUserIfKnown;
-                      BlocProvider.of<VaultCubit>(context).save(user);
+                      await iam.showIfAppropriate(InAppMessageTrigger.vaultSaved);
+                      User? user = accountCubit.currentUserIfKnown;
+                      vaultCubit.save(user);
                     }
                   : null,
               child: Text(str.save.toUpperCase()),

--- a/lib/widgets/vault_loader.dart
+++ b/lib/widgets/vault_loader.dart
@@ -149,7 +149,8 @@ class VaultLoaderState extends State<VaultLoaderWidget> {
         BlocProvider.of<FilterCubit>(context)
             .start(state.vault.files.current.body.rootGroup.uuid.uuid, Settings.getValue<bool>('expandGroups', true));
         await BlocProvider.of<InteractionCubit>(context).databaseOpened();
-        AppConfig.router.navigateTo(context, Routes.vault, replace: true);
+        // context my have become detached from widget tree by this point
+        AppConfig.router.navigateTo(AppConfig.navigatorKey.currentContext!, Routes.vault, replace: true);
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.5+24
+version: 1.0.6+26
 
 environment:
   sdk: '>=2.16.0 <3.0.0'


### PR DESCRIPTION
Is a specific instance of a more general fault where context could be
lost during async operations. This case was noticed because the recently
added code to store and flush data to shared storage takes long enough
that Flutter has an increased chance to destroy the old context and this
actually happened on some devices. I've investigated other instances
of this problem and either developed a more defensive algorithm or
commented when it is uncertain whether the problem is applicable or not.